### PR TITLE
Fixed lowercase letter typo in 2018 Illustrator

### DIFF
--- a/Illustrator/2018/index.d.ts
+++ b/Illustrator/2018/index.d.ts
@@ -5060,7 +5060,7 @@ declare class Lines {
 	 */
 	length: number;
 
-	[n: number]: pathItem;
+	[n: number]: PathItem;
 
 	/**
 	 * The object's container.


### PR DESCRIPTION
Fixed typo causing error on running tsc transpiling.